### PR TITLE
Fix typo in Pyradmid/Pyramid

### DIFF
--- a/exercises/Pyradmid/index.js
+++ b/exercises/Pyradmid/index.js
@@ -20,4 +20,4 @@ const pyramid = (n) => {
 
 }
 
-module.exports = pyradmid;
+module.exports = pyramid;


### PR DESCRIPTION
Change the export from `pyradmid` to match the changed function name `pyramid`