### PR TITLE
Fixed repo to clone in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Series of interesting JavaScript exercises that I solve during my education. For
 Clone the repo.
 
 ```bash
-$ git clone https://github.com/appalaszynski/switch-gulp-to-webpack.git
+$ git clone https://github.com/appalaszynski/javascript-exercises.git
 ```
 
 Install Jest globally.


### PR DESCRIPTION
Changed from `switch-gulp-to-webpack.git` to `javascript-exercises.git`